### PR TITLE
Increased build number because of PR

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - remove_extras.patch
 
 build:
-  number: 0
+  number: 1
   noarch: python
   skip: True  # [py2k]
   script: python -m pip install --no-deps --ignore-installed .


### PR DESCRIPTION
I believe you're supposed to increase the build number when there's a new commit on master, but not a new version.

PR merged without increasing version number:
https://github.com/agronholm/sphinx-autodoc-typehints/pull/55

Fixes a compatibility issue with newer sphinx.